### PR TITLE
Fix very slow GitHub deps on rpm 6

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -20,6 +20,9 @@ jobs:
       with:
         node-version: '14'
 
+    - name: Fix github deps
+      run: git config --global url."https://git@".insteadOf git://
+
     - name: Remember package.json hash
       id: vars
       run: echo ::set-output name=package_json_hash::$(cat package.json | openssl dgst -sha256 -binary | xxd -p -c 256)


### PR DESCRIPTION
See: https://github.com/npm/cli/issues/4896

NPM uses git protocol which is no longer available @github. This command replaces it with https protocol 