### PR TITLE
Optional install apt packages before testing and before preparing

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -2,6 +2,10 @@ name: Codecov master
 
 on:
   workflow_call:
+    inputs:
+      aptPackages:
+        required: false
+        type: string
     secrets:
       NPM_TOKEN:
         required: true
@@ -23,6 +27,9 @@ jobs:
     - run: npm install
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: Install packages
+      run: sudo apt-get install -y ${{ inputs.aptPackages }}
+      if: ${{ inputs.aptPackages }}
     - run: npm run | grep prepare > /dev/null && npm run-script prepare || true
     - run: npm run codecov
     - uses: codecov/codecov-action@v2

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -18,6 +18,9 @@ on:
       postgres-name:
         required: false
         type: string
+      aptPackages:
+        required: false
+        type: string
 
 jobs:
   integrationtest:
@@ -75,6 +78,10 @@ jobs:
       uses: shogo82148/actions-setup-mysql@v1
       with:
         mysql-version: '5.7'
+
+    - name: Install packages
+      run: sudo apt-get install -y ${{ inputs.aptPackages }}
+      if: ${{ inputs.aptPackages }}
 
     - run: npm run | grep prepare > /dev/null && npm run-script prepare || true
     - run: npm run integrationtest

--- a/.github/workflows/integrationtest_njs18.yml
+++ b/.github/workflows/integrationtest_njs18.yml
@@ -18,6 +18,10 @@ on:
       postgres-name:
         required: false
         type: string
+      aptPackages:
+        required: false
+        type: string
+
 
 jobs:
   integrationtest:
@@ -75,6 +79,10 @@ jobs:
       uses: shogo82148/actions-setup-mysql@v1
       with:
         mysql-version: '5.7'
+
+    - name: Install packages
+      run: sudo apt-get install -y ${{ inputs.aptPackages }}
+      if: ${{ inputs.aptPackages }}
 
     - run: npm run | grep prepare > /dev/null && npm run-script prepare || true
     - run: npm run integrationtest

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -2,6 +2,10 @@ name: Unit tests
 
 on:
   workflow_call:
+    inputs:
+      packages:
+        required: false
+        type: string
     secrets:
       CODECOV_TOKEN:
         required: true
@@ -24,6 +28,10 @@ jobs:
       with:
         path: node_modules
         key: ${{ runner.os }}-cache-node-modules-${{steps.vars.outputs.package_json_hash}}
+
+    - name: Install packages
+      run: sudo apt-get install -y ${{ inputs.packages }}
+      if: ${{ inputs.packages }}
 
     - run: npm run | grep prepare > /dev/null && npm run-script prepare || true
     - run: npm test

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -3,7 +3,7 @@ name: Unit tests
 on:
   workflow_call:
     inputs:
-      packages:
+      aptPackages:
         required: false
         type: string
     secrets:
@@ -30,8 +30,8 @@ jobs:
         key: ${{ runner.os }}-cache-node-modules-${{steps.vars.outputs.package_json_hash}}
 
     - name: Install packages
-      run: sudo apt-get install -y ${{ inputs.packages }}
-      if: ${{ inputs.packages }}
+      run: sudo apt-get install -y ${{ inputs.aptPackages }}
+      if: ${{ inputs.aptPackages }}
 
     - run: npm run | grep prepare > /dev/null && npm run-script prepare || true
     - run: npm test

--- a/.github/workflows/unittest_njs18.yml
+++ b/.github/workflows/unittest_njs18.yml
@@ -2,6 +2,10 @@ name: Unit tests
 
 on:
   workflow_call:
+    inputs:
+      aptPackages:
+        required: false
+        type: string
     secrets:
       CODECOV_TOKEN:
         required: true
@@ -24,6 +28,10 @@ jobs:
       with:
         path: node_modules
         key: ${{ runner.os }}-cache-node-18-modules-${{steps.vars.outputs.package_json_hash}}
+
+    - name: Install packages
+      run: sudo apt-get install -y ${{ inputs.aptPackages }}
+      if: ${{ inputs.aptPackages }}
 
     - run: npm run | grep prepare > /dev/null && npm run-script prepare || true
     - run: npm test


### PR DESCRIPTION
`npm prepare` is run before testing but:

If you want specific apt packages to be installed `npm prepare` feels not as the correct way. 