### PR TITLE
Flaky testing validation

### DIFF
--- a/.github/workflows/setup_njs18.yml
+++ b/.github/workflows/setup_njs18.yml
@@ -7,6 +7,10 @@ on:
         required: true
       CI_SSH_KEY:
         required: false
+    inputs:
+      skipValidations:
+        required: false
+        type: boolean
 
 jobs:
   setup:
@@ -18,6 +22,7 @@ jobs:
       with:
         npm_token: ${{ secrets.NPM_TOKEN }}
         ci_ssh_key: ${{ secrets.CI_SSH_KEY }}
+      if: ${{ ! inputs.skipValidations }}
 
     - uses: actions/setup-node@v3
       with:

--- a/.github/workflows/setup_njs20.yml
+++ b/.github/workflows/setup_njs20.yml
@@ -7,6 +7,10 @@ on:
         required: true
       CI_SSH_KEY:
         required: false
+    inputs:
+      skipValidations:
+        required: false
+        type: boolean
 
 jobs:
   setup:
@@ -18,6 +22,7 @@ jobs:
       with:
         npm_token: ${{ secrets.NPM_TOKEN }}
         ci_ssh_key: ${{ secrets.CI_SSH_KEY }}
+      if: ${{ ! inputs.skipValidations }}
 
     - uses: actions/setup-node@v3
       with:

--- a/.github/workflows/unittest_njs18.yml
+++ b/.github/workflows/unittest_njs18.yml
@@ -6,6 +6,10 @@ on:
       aptPackages:
         required: false
         type: string
+    inputs:
+      skipFlakyCheck:
+        required: false
+        type: boolean
     secrets:
       CODECOV_TOKEN:
         required: true
@@ -39,6 +43,7 @@ jobs:
       run: npm test
     - name: Run unit tests multiple times to find flaky tests
       run: for i in `seq 5`; do npm test; done
+      if: ${{ ! inputs.skipFlakyCheck }}
     - name: Linting
       run: ./node_modules/eslint/bin/eslint.js --quiet -c node_modules/@flitsmeister/eslint/.eslintrc --ignore-pattern node_modules --ignore-pattern helpers --ignore-pattern public --ignore-pattern web --ignore-pattern build --ignore-pattern src .
     - name: Install npm packages

--- a/.github/workflows/unittest_njs18.yml
+++ b/.github/workflows/unittest_njs18.yml
@@ -6,7 +6,6 @@ on:
       aptPackages:
         required: false
         type: string
-    inputs:
       skipFlakyCheck:
         required: false
         type: boolean
@@ -42,7 +41,7 @@ jobs:
     - name: Run unit tests
       run: npm test
     - name: Run unit tests multiple times to find flaky tests
-      run: "for i in `seq 5`; do npm test; done"
+      run: for i in `seq 5`; do npm test; done
       if: ${{ ! inputs.skipFlakyCheck }}
     - name: Linting
       run: ./node_modules/eslint/bin/eslint.js --quiet -c node_modules/@flitsmeister/eslint/.eslintrc --ignore-pattern node_modules --ignore-pattern helpers --ignore-pattern public --ignore-pattern web --ignore-pattern build --ignore-pattern src .

--- a/.github/workflows/unittest_njs18.yml
+++ b/.github/workflows/unittest_njs18.yml
@@ -33,13 +33,18 @@ jobs:
       run: sudo apt-get update; sudo apt-get install -y ${{ inputs.aptPackages }}
       if: ${{ inputs.aptPackages }}
 
-    - run: npm run | grep setup > /dev/null && npm run-script setup || true
-    - run: npm test
-    - run: ./node_modules/eslint/bin/eslint.js --quiet -c node_modules/@flitsmeister/eslint/.eslintrc --ignore-pattern node_modules --ignore-pattern helpers --ignore-pattern public --ignore-pattern web --ignore-pattern build --ignore-pattern src .
-
+    - name: Run setup script if available
+      run: npm run | grep setup > /dev/null && npm run-script setup || true
+    - name: Run unit tests
+      run: npm test
+    - name: Run unit tests multiple times to find flaky tests
+      run: for i in `seq 5`; do npm test; done
+    - name: Linting
+      run: ./node_modules/eslint/bin/eslint.js --quiet -c node_modules/@flitsmeister/eslint/.eslintrc --ignore-pattern node_modules --ignore-pattern helpers --ignore-pattern public --ignore-pattern web --ignore-pattern build --ignore-pattern src .
     - name: Install npm packages
       run: npm install -g nyc
-    - run: nyc --reporter=json npm test -- -v
+    - name: Code coverage
+      run: nyc --reporter=json npm test -- -v
     - uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unittest_njs18.yml
+++ b/.github/workflows/unittest_njs18.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Run unit tests
       run: npm test
     - name: Run unit tests multiple times to find flaky tests
-      run: for i in `seq 5`; do npm test; done
+      run: "for i in `seq 5`; do npm test; done"
       if: ${{ ! inputs.skipFlakyCheck }}
     - name: Linting
       run: ./node_modules/eslint/bin/eslint.js --quiet -c node_modules/@flitsmeister/eslint/.eslintrc --ignore-pattern node_modules --ignore-pattern helpers --ignore-pattern public --ignore-pattern web --ignore-pattern build --ignore-pattern src .

--- a/.github/workflows/unittest_njs20.yml
+++ b/.github/workflows/unittest_njs20.yml
@@ -33,6 +33,9 @@ jobs:
       run: sudo apt-get update; sudo apt-get install -y ${{ inputs.aptPackages }}
       if: ${{ inputs.aptPackages }}
 
-    - run: npm run | grep setup > /dev/null && npm run-script setup || true
-    - run: npm test
-    - run: ./node_modules/eslint/bin/eslint.js --quiet -c node_modules/@flitsmeister/eslint/.eslintrc --ignore-pattern node_modules --ignore-pattern helpers --ignore-pattern public --ignore-pattern web --ignore-pattern build --ignore-pattern src .
+    - name: Run setup script if available
+      run: npm run | grep setup > /dev/null && npm run-script setup || true
+    - name: Run unit tests
+      run: npm test
+    - name: Run unit tests multiple times to find flaky tests
+      run: for i in `seq 5`; do npm test; done

--- a/.github/workflows/unittest_njs20.yml
+++ b/.github/workflows/unittest_njs20.yml
@@ -42,5 +42,5 @@ jobs:
     - name: Run unit tests
       run: npm test
     - name: Run unit tests multiple times to find flaky tests
-      run: for i in `seq 5`; do npm test; done
+      run: "for i in `seq 5`; do npm test; done"
       if: ${{ ! inputs.skipFlakyCheck }}

--- a/.github/workflows/unittest_njs20.yml
+++ b/.github/workflows/unittest_njs20.yml
@@ -6,6 +6,10 @@ on:
       aptPackages:
         required: false
         type: string
+    inputs:
+      skipFlakyCheck:
+        required: false
+        type: boolean
     secrets:
       CODECOV_TOKEN:
         required: true
@@ -39,3 +43,4 @@ jobs:
       run: npm test
     - name: Run unit tests multiple times to find flaky tests
       run: for i in `seq 5`; do npm test; done
+      if: ${{ ! inputs.skipFlakyCheck }}

--- a/.github/workflows/unittest_njs20.yml
+++ b/.github/workflows/unittest_njs20.yml
@@ -6,7 +6,6 @@ on:
       aptPackages:
         required: false
         type: string
-    inputs:
       skipFlakyCheck:
         required: false
         type: boolean
@@ -42,5 +41,5 @@ jobs:
     - name: Run unit tests
       run: npm test
     - name: Run unit tests multiple times to find flaky tests
-      run: "for i in `seq 5`; do npm test; done"
+      run: for i in `seq 5`; do npm test; done
       if: ${{ ! inputs.skipFlakyCheck }}


### PR DESCRIPTION
By default run unit tests 5 times extra, in a new step
You can disable it (only do it temporary) with `skipFlakyCheck`

Added an extra option to allow skipping validations. This gives you the option to try tests with .only on CI. Don't commit this to master