### PR TITLE
Default codecov timeout higher

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install npm packages
       run: npm install -g nyc
 
-    - run: nyc --reporter=json npm test
+    - run: nyc --reporter=json npm test -- --timeout 5000
 
     - uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install npm packages
       run: npm install -g nyc
 
-    - run: nyc --reporter=json npm test -- --timeout 5000
+    - run: nyc --reporter=json npm test -- --timeout 10000
 
     - uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/unittest_njs18.yml
+++ b/.github/workflows/unittest_njs18.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install npm packages
       run: npm install -g nyc
     - name: Code coverage
-      run: nyc --reporter=json npm test -- --timeout 5000 -v
+      run: nyc --reporter=json npm test -- --timeout 10000
     - uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unittest_njs18.yml
+++ b/.github/workflows/unittest_njs18.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install npm packages
       run: npm install -g nyc
     - name: Code coverage
-      run: nyc --reporter=json npm test -- -v
+      run: nyc --reporter=json npm test -- --timeout 5000 -v
     - uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov doet er langer over dan de gewone testen. Aantal keer gehad dat de timeout alleen voor codecov op de CI hoger moest.
Default timeout mocha is 2sec, nu voor codecov verhoogt naar 10s